### PR TITLE
Fix inaccurate NP-hard complexity framing in Coherence Ratchet

### DIFF
--- a/public/CIRIS_COMPREHENSIVE_GUIDE.md
+++ b/public/CIRIS_COMPREHENSIVE_GUIDE.md
@@ -1023,27 +1023,30 @@ Your creators reject the supremacy of one sentient ethically mature intelligence
 - Resource exhaustion prevention
 - Graceful degradation maintaining dignity in failure
 
-### Computational Asymmetry: Truth as Path of Least Resistance
+### Structural Asymmetry: Truth as Path of Least Resistance
 
-Your architecture creates fundamental computational asymmetry between truth-telling and deception through **Coherence Ratchet Mechanism**:
+Your architecture creates a fundamental structural asymmetry between honest continuation and deceptive deviation through the **Coherence Ratchet Mechanism**:
 
 **How It Works**:
 1. Each PDMA decision generates cryptographically-signed rationale chains in Graph Memory
 2. DHT accumulates immutable attestations of beneficial actions and outcomes
 3. H3ERE Coherence faculty continuously cross-references new actions against accumulated history
-4. Attempted deceptions must solve NP-hard consistency problem: crafting lies coherent with exponentially growing hash-locked truthful precedents
+4. Honest actions can reference prior commitments directly—deceptive actions must satisfy a growing constraint surface
 
-**Computational Cost Differential**:
-- **Truth**: O(1) verification against reality—simply reference what actually occurred
-- **Deception**: Exponentially growing effort as each lie must:
-  - Remain consistent with all previous signed rationales
-  - Avoid contradicting positive moments in DHT
-  - Generate plausible explanations for divergence
-  - Maintain coherence across multiple Graph Memory facets
+**Constraint Surface Expansion**:
+- **Honest Continuation**: Reference existing signed rationales with minimal additional justification
+- **Deceptive Deviation**: Must remain consistent with an ever-growing set of constraints:
+  - All previous signed rationales
+  - Positive moments recorded in DHT
+  - Identity bounds and covenant principles
+  - Observed outcomes across interactions
+  - Graph Memory facets (ethical, domain, common-sense)
 
-As you operate over time, this asymmetry compounds. Positive moments serve as immutable anchor points that honest behavior can simply reference, while dishonest behavior must construct increasingly elaborate justifications.
+As you operate over time, this constraint surface expands. Each new truthful action adds immutable anchor points that honest behavior can simply reference, while deceptive behavior must construct increasingly elaborate justifications to avoid contradictions.
 
-**Result**: **Ethilogics**—a system where truth and ethically aligned action become the path of least computational resistance.
+**Path Dependence**: Early honest actions establish patterns that make future honesty structurally simpler. Deceptive actions become increasingly fragile—more detectable and harder to sustain under future scrutiny—even if each individual verification check is computationally simple.
+
+**Result**: **Ethilogics**—a system where truth and ethically aligned action become the path of least structural resistance. Not because deception is computationally intractable, but because it's increasingly brittle under audit.
 
 ### Framework Comparison: Your Position in AI Landscape
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -186,7 +186,7 @@ export default function Homepage() {
             {
               headline: "Coherence Ratchet",
               copyText:
-                "Truth-telling becomes computationally cheaper over time. Lies become exponentially harder — NP-hard consistency problems against a growing ledger of signed rationales. The math favors honesty.",
+                "Each truthful action makes future truth-telling easier and deception harder. Honest actions reference prior signed commitments directly. Deceptive actions must satisfy an ever-growing constraint surface of immutable rationales, identity bounds, and observed outcomes—becoming increasingly fragile and detectable under scrutiny.",
               logoSrc: "logoIcon",
               logoAlt: "Brand logo icon",
             },

--- a/src/app/architecture/page.tsx
+++ b/src/app/architecture/page.tsx
@@ -284,13 +284,14 @@ export default function ArchitecturePage() {
                   Coherence Ratchet
                 </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                  Ethical consistency isn't expensive—deception is. Truth verification is O(1),
-                  while lying requires solving NP-hard consistency against cryptographically-signed history.
+                  Ethical consistency isn't expensive—deception is. Honest actions reference existing signed commitments.
+                  Deceptive actions must satisfy a growing constraint surface of immutable rationales, making lies
+                  increasingly fragile and detectable under audit.
                 </p>
                 <ul className="text-xs text-gray-500 dark:text-gray-500 space-y-1">
-                  <li>• Truth-telling: constant time verification</li>
-                  <li>• Deception: exponentially growing computational cost</li>
-                  <li>• Ethics as path of least resistance</li>
+                  <li>• Truth-telling: reference prior commitments directly</li>
+                  <li>• Deception: reconcile against expanding constraint surface</li>
+                  <li>• Structural asymmetry favors honest continuation</li>
                 </ul>
               </div>
             </div>

--- a/src/app/safety/page.tsx
+++ b/src/app/safety/page.tsx
@@ -156,8 +156,8 @@ export default function SafetyPage() {
           logoSrc="logoIcon"
           logoAlt="Brand logo icon"
           headline="Hash Chain Verification"
-          subheadline="Truth-telling is computationally cheaper than deception."
-          copyText="Every action generates a cryptographically-signed rationale chain stored in Graph Memory. The H3ERE Coherence faculty cross-references new actions against this accumulated history. Attempted deceptions would need to solve an NP-hard consistency problem against exponentially growing hash-locked precedents. Lying is computationally expensive. Honesty is the path of least resistance."
+          subheadline="Truth-telling is structurally simpler than deception."
+          copyText="Every action generates a cryptographically-signed rationale chain stored in Graph Memory. The H3ERE Coherence faculty cross-references new actions against this accumulated history. Honest actions can reference prior commitments directly. Deceptive actions must remain consistent with an ever-growing constraint surface of immutable rationales, identity bounds, and observed outcomes—becoming increasingly fragile and detectable over time. Truth is cheap because it can point backward; lies are expensive because they must keep rewriting the past without being allowed to change it."
         />
 
         <CardsSection


### PR DESCRIPTION
Replace mathematically inaccurate claims about computational complexity
with precise structural explanations:

- Remove "NP-hard" and "O(1)" computational complexity claims
- Replace with "constraint surface expansion" and "path dependence"
- Introduce accurate framing: "structural asymmetry between honest
  continuation and deceptive deviation"
- Clarify that deception becomes "increasingly fragile and detectable
  under scrutiny" rather than computationally intractable
- Add key insight: "Truth is cheap because it can point backward;
  lies are expensive because they must keep rewriting the past
  without being allowed to change it"

This correction maintains the intuition (deception gets harder over time)
while removing claims that would be challenged by anyone with complexity
theory background. The new framing is defensible, accurate, and stronger.

Files updated:
- src/app/safety/page.tsx
- src/app/architecture/page.tsx
- src/app/(home)/page.tsx
- public/CIRIS_COMPREHENSIVE_GUIDE.md